### PR TITLE
Use fork of node-usb to disable libudev

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@types/node": "^6.0.112",
     "debug": "^3.1.0",
-    "usb": "^1.3.2"
+    "usb": "github:resin-io/node-usb#1.3.5"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.20",


### PR DESCRIPTION
Same as https://github.com/resin-io/etcher/commit/7e01eca7f5e5fa60311d805baa9f6e833bddc014

Change-Type: patch