### PR TITLE
Remove mutex in epWrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@types/node": "^6.0.112",
-    "async-mutex": "^0.1.3",
     "debug": "^3.1.0",
     "usb": "github:resin-io/node-usb#1.3.5"
   },


### PR DESCRIPTION
But split the data being transferred in 1MiB chunks.
This way we shouldn't saturate the usb bus.

Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>