### PR TITLE
Claim usb interface before running usbboot

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -204,6 +204,7 @@ const initializeDevice = (device: usb.Device): { iface: usb.Interface, endpoint:
 		endpointNumber = 3;
 	}
 	const iface = device.interface(interfaceNumber);
+	iface.claim();
 	const endpoint = iface.endpoint(endpointNumber);
 	debug('Initialized device correctly', portId(device));
 	return { iface, endpoint };


### PR DESCRIPTION
Otherwise the bulk transfer fails on macOS.

Change-type: patch